### PR TITLE
Move Readme references to issues.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,4 +7,10 @@ Listings are organized using labels.
 Feel free to create a new issue if you have a position to fill, are actively looking for work, or just want to passively be included as available for hire.
 We will try to keep the data fresh by periodically pinging "old" issues for current status.
 
-Have questions? Ask.
+
+## Predefined Searches
+
+ - [Who is Hiring?](https://github.com/tech256/jobs/issues?q=is%3Aissue+is%3Aopen+label%3AHiring)
+ - [Who Wants to Be Hired?](https://github.com/tech256/jobs/issues?q=is%3Aissue+is%3Aopen+label%3A%22Hire+me%3F%22)
+ - [Freelancer?](https://github.com/tech256/jobs/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3AFreelance+label%3AHiring)
+ - [Seeking Freelancer?](https://github.com/tech256/jobs/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3AFreelance+label%3A%22Hire+me%3F%22)


### PR DESCRIPTION
Remove the other markdowns and make the links go to pre-defined searches.